### PR TITLE
Feature add logger to public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.2] - 2023-09-06
+
+### Improvements: 
++ Now you can pass along a logging function that will report some Recco internal errors to integrators.
+
 ## [1.0.1] - 2023-08-19
 
 ### Improvements: 

--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ YourAwesomeView()
 Our [CHANGELOG.md](./CHANGELOG.md) contains information on all releases.
 
 [Recco-Flutter]:https://github.com/viluahealthcare/recco-flutter-showcase
-[Recco-Android]:https://github.com/sf-recco/flutter-plugin
+[Recco-Android]:https://github.com/SignificoHealth/flutter-plugin

--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ ReccoUI.initialize(
 )
 ```
 
+#### Internal errors
+
+If your application ever has the need to react to any of Recco's internal errors, than you can supply a closure through the `initialize` method like so: 
+
+```swift
+import ReccoUI
+
+ReccoUI.initialize(
+    clientSecret: "<myClientSecret>",
+    style: .summer // or your previously created ReccoStyle,
+    logger: { (error: Error) in print(error) }
+)
+```
+
 __Be mindful that if you don't initialize the SDK before using it, everything will just error out.__
 
 ### Logging in and out
@@ -155,7 +169,5 @@ YourAwesomeView()
 
 Our [CHANGELOG.md](./CHANGELOG.md) contains information on all releases.
 
-[PAT]:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
-[Github-Recco]:https://github.com/orgs/viluahealthcare/packages?repo_name=recco-ios-sdk
 [Recco-Flutter]:https://github.com/viluahealthcare/recco-flutter-showcase
-[Recco-Android]:https://github.com/viluahealthcare/recco-android-sdk
+[Recco-Android]:https://github.com/sf-recco/flutter-plugin

--- a/ReccoHeadless.podspec
+++ b/ReccoHeadless.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = 'ReccoHeadless'
-  spec.version       = '1.0.1'
+  spec.version       = '1.0.2'
   spec.license       = { :type => 'Significo 2023 ©' }
   spec.homepage      = 'https://github.com/sf-recco/ios-sdk'
   spec.authors       = { 'Significo' => 'recco@significo.com' }

--- a/ReccoUI.podspec
+++ b/ReccoUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name          = 'ReccoUI'
-  spec.version       = '1.0.1'
+  spec.version       = '1.0.2'
   spec.license       = { :type => 'Significo 2023 ©' }
   spec.homepage      = 'https://github.com/sf-recco/ios-sdk'
   spec.authors       = { 'Significo' => 'recco@significo.com' }

--- a/Sources/ReccoUI/Article/ArticleDetailViewModel.swift
+++ b/Sources/ReccoUI/Article/ArticleDetailViewModel.swift
@@ -8,7 +8,8 @@ final class ArticleDetailViewModel: ObservableObject {
     private let updateContentSeen: (ContentId) -> Void
     private let onBookmarkChanged: (Bool) -> Void
     private let nav: ReccoCoordinator
-    
+    private let logger: Logger
+
     let imageUrl: URL?
     let heading: String
     
@@ -21,7 +22,8 @@ final class ArticleDetailViewModel: ObservableObject {
         loadedContent: (ContentId, String, URL?, (ContentId) -> Void, (Bool) -> Void),
         articleRepo: ArticleRepository,
         contentRepo: ContentRepository,
-        nav: ReccoCoordinator
+        nav: ReccoCoordinator,
+        logger: Logger
     ) {
         self.articleRepo = articleRepo
         self.contentRepo = contentRepo
@@ -31,6 +33,7 @@ final class ArticleDetailViewModel: ObservableObject {
         self.updateContentSeen = loadedContent.3
         self.onBookmarkChanged = loadedContent.4
         self.nav = nav
+        self.logger = logger
     }
     
     @MainActor
@@ -41,6 +44,7 @@ final class ArticleDetailViewModel: ObservableObject {
             self.article?.status = .viewed
             self.updateContentSeen(article.id)
         } catch {
+            logger.log(error)
             initialLoadError = error
         }
         
@@ -61,6 +65,7 @@ final class ArticleDetailViewModel: ObservableObject {
             self.article?.bookmarked.toggle()
             self.onBookmarkChanged(!article.bookmarked)
         } catch {
+            logger.log(error)
             actionError = error
         }
 
@@ -80,6 +85,7 @@ final class ArticleDetailViewModel: ObservableObject {
 
             self.article?.rating = rating
         } catch {
+            logger.log(error)
             actionError = error
         }
 

--- a/Sources/ReccoUI/Assembly.swift
+++ b/Sources/ReccoUI/Assembly.swift
@@ -2,8 +2,22 @@ import ReccoHeadless
 import SwiftUI
 
 final class ReccoUIAssembly: ReccoAssembly {
-    init() {}
+    let logger: Logger
+    
+    init(
+        logger: Logger = Logger { _ in }
+    ) {
+        self.logger = logger
+    }
+    
     func assemble(container: ReccoContainer) {
+        container.register(
+            type: Logger.self,
+            singleton: true
+        ) { [unowned self] _ in
+            logger
+        }
+        
         container.register(type: ReccoCoordinator.self) { r in
             DefaultReccoCoordinator(window: r.get())
         }
@@ -12,7 +26,8 @@ final class ReccoUIAssembly: ReccoAssembly {
             DashboardViewModel(
                 feedRepo: r.get(),
                 recRepo: r.get(),
-                nav: r.get()
+                nav: r.get(),
+                logger: r.get()
             )
         }
         
@@ -21,14 +36,16 @@ final class ReccoUIAssembly: ReccoAssembly {
                 loadedContent: tuple,
                 articleRepo: r.get(),
                 contentRepo: r.get(),
-                nav: r.get()
+                nav: r.get(),
+                logger: r.get()
             )
         }
         
         container.register(type: OnboardingOutroViewModel.self) { r in
             OnboardingOutroViewModel(
                 meRepo: r.get(),
-                nav: r.get()
+                nav: r.get(),
+                logger: r.get()
             )
         }
         
@@ -47,7 +64,8 @@ final class ReccoUIAssembly: ReccoAssembly {
                 topic: tuple.0,
                 reloadSection: tuple.1,
                 repo: r.get(),
-                nav: r.get()
+                nav: r.get(),
+                logger: r.get()
             )
         }
         
@@ -55,14 +73,16 @@ final class ReccoUIAssembly: ReccoAssembly {
             OnboardingQuestionnaireViewModel(
                 nextScreen: next,
                 repo: r.get(),
-                nav: r.get()
+                nav: r.get(),
+                logger: r.get()
             )
         }
         
         container.register(type: BookmarksViewModel.self) { r in
             BookmarksViewModel(
                 recRepo: r.get(),
-                nav: r.get()
+                nav: r.get(),
+                logger: r.get()
             )
         }
     }

--- a/Sources/ReccoUI/Bookmarks/BookmarksViewModel.swift
+++ b/Sources/ReccoUI/Bookmarks/BookmarksViewModel.swift
@@ -4,15 +4,18 @@ import ReccoHeadless
 final class BookmarksViewModel: ObservableObject {
     private let recRepo: RecommendationRepository
     private let nav: ReccoCoordinator
-    
+    private let logger: Logger
+
     @Published var isLoading: Bool = true
     @Published var items: [AppUserRecommendation] = []
     @Published var error: Error?
     
     init(
         recRepo: RecommendationRepository,
-        nav: ReccoCoordinator
+        nav: ReccoCoordinator,
+        logger: Logger
     ) {
+        self.logger = logger
         self.recRepo = recRepo
         self.nav = nav
     }
@@ -45,6 +48,7 @@ final class BookmarksViewModel: ObservableObject {
             let items = try await recRepo.getBookmarks()
             self.items = items
         } catch {
+            logger.log(error)
             self.error = error
         }
         

--- a/Sources/ReccoUI/Dashboard/DashboardView/DashboardViewModel.swift
+++ b/Sources/ReccoUI/Dashboard/DashboardView/DashboardViewModel.swift
@@ -10,6 +10,7 @@ final class DashboardViewModel: ObservableObject {
     private let feedRepo: FeedRepository
     private let recRepo: RecommendationRepository
     private let nav: ReccoCoordinator
+    private let logger: Logger
     
     @Published var lockedSectionAlert: FeedSection?
     @Published var isLoading: Bool = true
@@ -22,11 +23,13 @@ final class DashboardViewModel: ObservableObject {
     init(
         feedRepo: FeedRepository,
         recRepo: RecommendationRepository,
-        nav: ReccoCoordinator
+        nav: ReccoCoordinator,
+        logger: Logger
     ) {
         self.recRepo = recRepo
         self.feedRepo = feedRepo
         self.nav = nav
+        self.logger = logger
         
         Task {
             await getFeedItems()
@@ -83,6 +86,7 @@ final class DashboardViewModel: ObservableObject {
             setView(sections: data)
             await load(sections: data)
         } catch {
+            logger.log(error)
             initialLoadError = error
             isLoading = false
         }
@@ -99,6 +103,7 @@ final class DashboardViewModel: ObservableObject {
                         self.items[section.type] = items
                         self.errors[section] = nil
                     } catch {
+                        logger.log(error)
                         self.initialLoadError = error
                     }
                     
@@ -132,6 +137,7 @@ final class DashboardViewModel: ObservableObject {
                 let data = try await recRepo.getFeedSection(section)
                 items[section.type] = data
             } catch {
+                logger.log(error)
                 self.initialLoadError = error
             }
             

--- a/Sources/ReccoUI/Onboarding/Outro/OnboardingOutroViewModel.swift
+++ b/Sources/ReccoUI/Onboarding/Outro/OnboardingOutroViewModel.swift
@@ -4,16 +4,19 @@ import ReccoHeadless
 final class OnboardingOutroViewModel: ObservableObject {
     private let meRepo: MeRepository
     private let nav: ReccoCoordinator
+    private let logger: Logger
     
     @Published var isLoading: Bool = false
     @Published var meError: Error?
 
     init(
         meRepo: MeRepository,
-        nav: ReccoCoordinator
+        nav: ReccoCoordinator,
+        logger: Logger
     ) {
         self.meRepo = meRepo
         self.nav = nav
+        self.logger = logger
     }
     
     func close() {
@@ -26,6 +29,7 @@ final class OnboardingOutroViewModel: ObservableObject {
         do {
             try await meRepo.getMe()
         } catch {
+            logger.log(error)
             meError = error
         }
         isLoading = false

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -2,10 +2,6 @@ import Foundation
 import ReccoHeadless
 import SwiftUI
 
-enum ReccoError: Error {
-    case notInitialized
-}
-
 /**
  Configures Recco SDK given a clientSecret and a style (optional)
  - Parameters:
@@ -14,11 +10,16 @@ enum ReccoError: Error {
  */
 public func initialize(
     clientSecret: String,
-    style: ReccoStyle = .fresh
+    style: ReccoStyle = .fresh,
+    logger: @escaping (Error) -> Void  = { error in
+        #if DEBUG
+            print(error)
+        #endif
+    }
 ) {
     assemble([
         ReccoHeadlessAssembly(clientSecret: clientSecret),
-        ReccoUIAssembly()
+        ReccoUIAssembly(logger: Logger(log: logger))
     ])
     
     let keychain: KeychainProxy = get()
@@ -40,6 +41,7 @@ public func initialize(
 public func login(userId: String) async throws {
     let authRepository: AuthRepository
     let meRepository: MeRepository
+    
     do {
         authRepository = try tget()
         meRepository = try tget()

--- a/Sources/ReccoUI/Questionnaire/ViewModels/OnboardingQuestionnaireViewModel.swift
+++ b/Sources/ReccoUI/Questionnaire/ViewModels/OnboardingQuestionnaireViewModel.swift
@@ -5,11 +5,13 @@ final class OnboardingQuestionnaireViewModel: QuestionnaireViewModel {
     init(
         nextScreen: @escaping (Bool) -> Void,
         repo: QuestionnaireRepository,
-        nav: ReccoCoordinator
+        nav: ReccoCoordinator,
+        logger: Logger
     ) {
         super.init(
             repo: repo,
             nav: nav,
+            logger: logger,
             shouldValidateAllAnswersOnQuestionChange: true,
             mainButtonEnabledByDefault: false,
             nextScreen: nextScreen,

--- a/Sources/ReccoUI/Questionnaire/ViewModels/QuestionnaireViewModel.swift
+++ b/Sources/ReccoUI/Questionnaire/ViewModels/QuestionnaireViewModel.swift
@@ -9,7 +9,8 @@ class QuestionnaireViewModel: ObservableObject {
     private let nextScreen: (Bool) -> Void
     private let getQuestions: (QuestionnaireRepository) async throws -> [Question]
     private let sendQuestions: (QuestionnaireRepository, [CreateQuestionnaireAnswer]) async throws -> Void
-
+    private let logger: Logger
+    
     @Published var currentQuestion: Question?
     @Published var questions: [Question]?
     @Published var answers: [Question: CreateQuestionnaireAnswer?] = [:]
@@ -31,12 +32,14 @@ class QuestionnaireViewModel: ObservableObject {
     init(
         repo: QuestionnaireRepository,
         nav: ReccoCoordinator,
+        logger: Logger,
         shouldValidateAllAnswersOnQuestionChange: Bool,
         mainButtonEnabledByDefault: Bool,
         nextScreen: @escaping (Bool) -> Void,
         getQuestions: @escaping (QuestionnaireRepository) async throws -> [Question],
         sendQuestions: @escaping (QuestionnaireRepository, [CreateQuestionnaireAnswer]) async throws -> Void
     ) {
+        self.logger = logger
         self.repo = repo
         self.nextScreen = nextScreen
         self.getQuestions = getQuestions
@@ -111,6 +114,7 @@ class QuestionnaireViewModel: ObservableObject {
             })
             currentQuestion = questions?.first
         } catch {
+            logger.log(error)
             initialLoadError = error
         }
     }
@@ -162,6 +166,7 @@ class QuestionnaireViewModel: ObservableObject {
 
             nextScreen(didAnswerAllQuestions())
         } catch {
+            logger.log(error)
             sendError = error
         }
 

--- a/Sources/ReccoUI/Questionnaire/ViewModels/TopicQuestionnaireViewModel.swift
+++ b/Sources/ReccoUI/Questionnaire/ViewModels/TopicQuestionnaireViewModel.swift
@@ -6,11 +6,13 @@ final class TopicQuestionnaireViewModel: QuestionnaireViewModel {
         topic: ReccoTopic,
         reloadSection: @escaping (Bool) -> Void,
         repo: QuestionnaireRepository,
-        nav: ReccoCoordinator
+        nav: ReccoCoordinator,
+        logger: Logger
     ) {
         super.init(
             repo: repo,
             nav: nav,
+            logger: logger,
             shouldValidateAllAnswersOnQuestionChange: false,
             mainButtonEnabledByDefault: true,
             nextScreen: { answeredAll in

--- a/Sources/ReccoUI/System/HapticPlayer.swift
+++ b/Sources/ReccoUI/System/HapticPlayer.swift
@@ -1,4 +1,5 @@
 import CoreHaptics
+import ReccoHeadless
 
 enum HapticPattern: String {
     case unlock = "unlock_haptic"
@@ -12,6 +13,7 @@ final class HapticPlayer {
     private var engine: CHHapticEngine?
     private var player: CHHapticPatternPlayer?
     private var isPlaying: Bool = false
+    private let logger: Logger = get()
     
     func playHaptic(pattern: HapticPattern) {
         guard let url = localBundle.url(forResource: pattern.rawValue, withExtension: "ahap") else { return }
@@ -31,7 +33,7 @@ final class HapticPlayer {
             try engine?.start()
             try engine?.playPattern(from: url)
         } catch {
-            print("\(error)")
+            logger.log(error)
         }
     }
 }

--- a/Sources/ReccoUI/System/Logger.swift
+++ b/Sources/ReccoUI/System/Logger.swift
@@ -1,0 +1,7 @@
+enum ReccoError: Error {
+    case notInitialized
+}
+
+struct Logger {
+    let log: (Error) -> Void
+}

--- a/Tests/ReccoUITests/Mocks/MockAssembly.swift
+++ b/Tests/ReccoUITests/Mocks/MockAssembly.swift
@@ -1,20 +1,22 @@
 @testable import ReccoHeadless
+@testable import ReccoUI
 
 final class MockAssembly {
 
     static var mockAuthRepository = MockAuthRepository()
     static var mockMeRepository = MockMeRepository()
-
+    
     private static let container = ReccoSharedContainer.shared
 
-    static func assemble() {
+    static func assemble(didLog: @escaping () -> Void = {}) {
         // Reset dependencies
         mockAuthRepository = MockAuthRepository()
         mockMeRepository = MockMeRepository()
-
+        
         // Register dependencies
         container.register(type: AuthRepository.self, service: { _ in mockAuthRepository })
         container.register(type: MeRepository.self, service: { _ in mockMeRepository})
+        container.register(type: Logger.self, service: { _ in Logger { _ in didLog() } })
     }
 
     static func reset() {

--- a/Tests/ReccoUITests/Onboarding/OnboardingOutroViewModelTest.swift
+++ b/Tests/ReccoUITests/Onboarding/OnboardingOutroViewModelTest.swift
@@ -7,8 +7,9 @@ final class OnboardingOutroViewModelTest: XCTestCase {
     // MARK: - goToDashboardPressed
 
     func test_goToDashboardPressed_whenGetMeFails_throwsAnError() async throws {
+        let errorLogged = expectation(description: "Logger received error")
         let mockMeRepository = MockMeRepository()
-        let viewModel = OnboardingOutroViewModel(meRepo: mockMeRepository, nav: MockRecoCoordinator())
+        let viewModel = OnboardingOutroViewModel(meRepo: mockMeRepository, nav: MockRecoCoordinator(), logger: Logger { _ in errorLogged.fulfill() })
         let getMeError = NSError(domain: "getMeError", code: 0)
         mockMeRepository.getMeError = getMeError
         let getMeExpectation = expectation(description: "getMe was not called")
@@ -16,19 +17,21 @@ final class OnboardingOutroViewModelTest: XCTestCase {
 
         await viewModel.goToDashboardPressed()
 
-        await fulfillment(of: [getMeExpectation], timeout: 1)
+        await fulfillment(of: [getMeExpectation, errorLogged], timeout: 1)
         XCTAssertEqual(getMeError, viewModel.meError as? NSError)
     }
 
     func test_goToDashboardPressed_whenGetMeSucceeds_doesNotThrowsAnError() async throws {
+        let errorLogged = expectation(description: "Logger received error")
+        errorLogged.isInverted = true
         let mockMeRepository = MockMeRepository()
-        let viewModel = OnboardingOutroViewModel(meRepo: mockMeRepository, nav: MockRecoCoordinator())
+        let viewModel = OnboardingOutroViewModel(meRepo: mockMeRepository, nav: MockRecoCoordinator(), logger: Logger { _ in errorLogged.fulfill() })
         let getMeExpectation = expectation(description: "getMe was not called")
         mockMeRepository.expectations[.getMe] = getMeExpectation
 
         await viewModel.goToDashboardPressed()
 
-        await fulfillment(of: [getMeExpectation], timeout: 1)
+        await fulfillment(of: [getMeExpectation, errorLogged], timeout: 1)
         XCTAssertNil(viewModel.meError)
     }
 
@@ -36,7 +39,7 @@ final class OnboardingOutroViewModelTest: XCTestCase {
 
     func test_close_navigatesToDismiss() {
         let mockCoordinator = MockRecoCoordinator()
-        let viewModel = OnboardingOutroViewModel(meRepo: MockMeRepository(), nav: mockCoordinator)
+        let viewModel = OnboardingOutroViewModel(meRepo: MockMeRepository(), nav: mockCoordinator, logger: Logger {_ in})
         let expectedDestination = Destination.dismiss
         mockCoordinator.expectedDestination = expectedDestination
         let navigateExpectation = expectation(description: "navigate was not called with: \(expectedDestination)")

--- a/Tests/ReccoUITests/Onboarding/SplashViewModelTest.swift
+++ b/Tests/ReccoUITests/Onboarding/SplashViewModelTest.swift
@@ -21,7 +21,6 @@ final class SplashViewModelTest: XCTestCase {
         DispatchQueue.main.async { expectation.fulfill() }
         wait(for: [expectation], timeout: 1)
 
-
         XCTAssertEqual(user, viewModel.user)
     }
 }

--- a/Tests/ReccoUITests/Questionnaire/OnboardingQuestionnaireViewModelTest.swift
+++ b/Tests/ReccoUITests/Questionnaire/OnboardingQuestionnaireViewModelTest.swift
@@ -8,12 +8,14 @@ final class OnboardingQuestionnaireViewModelTest: XCTestCase {
     private func getViewModel(
         nextScreen: ((Bool) -> Void)? = nil,
         repo: QuestionnaireRepository? = nil,
-        nav: ReccoCoordinator? = nil
+        nav: ReccoCoordinator? = nil,
+        logger: Logger? = nil
     ) -> OnboardingQuestionnaireViewModel {
         return OnboardingQuestionnaireViewModel(
             nextScreen: nextScreen ?? { _ in },
             repo: repo ?? MockQuestionnaireRepository(),
-            nav: nav ?? MockRecoCoordinator()
+            nav: nav ?? MockRecoCoordinator(),
+            logger: logger ?? Logger { _ in}
         )
     }
 

--- a/Tests/ReccoUITests/Questionnaire/QuestionnaireViewModelTest.swift
+++ b/Tests/ReccoUITests/Questionnaire/QuestionnaireViewModelTest.swift
@@ -4,7 +4,15 @@ import XCTest
 
 @MainActor
 final class QuestionnaireViewModelTest: XCTestCase {
-
+    private var loggerLogError: XCTestExpectation!
+    
+    override func setUp() async throws {
+        loggerLogError = expectation(description: "Logger received an error")
+        loggerLogError.isInverted = true
+    }
+    
+    private func expectErrorLogging() { loggerLogError.isInverted = false }
+    
     let questions = Mocks.numericQuestions
     var answers: [Question: CreateQuestionnaireAnswer] {
         var result = [Question: CreateQuestionnaireAnswer]()
@@ -26,6 +34,7 @@ final class QuestionnaireViewModelTest: XCTestCase {
         return QuestionnaireViewModel(
             repo: repo ?? MockQuestionnaireRepository(),
             nav: nav ?? MockRecoCoordinator(),
+            logger: Logger { [unowned self] _ in loggerLogError.fulfill() },
             shouldValidateAllAnswersOnQuestionChange: shouldValidateAllAnswersOnQuestionChange ?? false,
             mainButtonEnabledByDefault: mainButtonEnabledByDefault ?? false,
             nextScreen: nextScreen ?? { _ in },
@@ -48,6 +57,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         viewModel.currentQuestion = questions.first
 
         XCTAssertTrue(viewModel.mainButtonEnabled)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_init_whenShouldValidateAllAnswersOnQuestionChangeIsTrue_callsValidateAnswerOnQuestionChange() throws {
@@ -62,6 +73,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         viewModel.currentQuestion = questions.first
 
         XCTAssertFalse(viewModel.mainButtonEnabled)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     // MARK: - previousQuestion
@@ -77,6 +90,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, 0)
         XCTAssertEqual(viewModel.currentQuestion, questions.first)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_previousQuestion_whenCurrentIndexIsHigherThanZero_changesCurrentQuestionToThePreviousOne() async {
@@ -90,6 +105,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, 0)
         XCTAssertEqual(viewModel.currentQuestion, questions.first)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     // MARK: - next
@@ -105,6 +122,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, 1)
         XCTAssertEqual(viewModel.currentQuestion, questions[1])
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_next_whenInLastQuestion_callsSendQuestions() async {
@@ -120,7 +139,7 @@ final class QuestionnaireViewModelTest: XCTestCase {
         XCTAssertEqual(viewModel.currentQuestion, questions.last)
         viewModel.next()
 
-        await fulfillment(of: [sendQuestionsExpectation], timeout: 1)
+        await fulfillment(of: [sendQuestionsExpectation, loggerLogError], timeout: 1)
     }
 
     // MARK: - answer
@@ -137,6 +156,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, 1)
         XCTAssertTrue(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsValidSingleChoiceAndLastQuestion_enablesMainButtonAndDoesNotCallsNext() async throws {
@@ -151,6 +172,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         XCTAssertTrue(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsValidNumericAndNotLastQuestion_enablesMainButtonAndDoesNotCallsNext() async throws {
@@ -165,6 +188,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, 0)
         XCTAssertTrue(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsLastQuestionAndShouldValidateAllAnswersOnQuestionChangeIsTrueAndAllAnswersAreValid_enablesMainButton() async throws {
@@ -184,6 +209,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         XCTAssertTrue(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsLastQuestionAndShouldValidateAllAnswersOnQuestionChangeIsTrueAndNotAllAnswersAreValid_disablesMainButton() async throws {
@@ -203,6 +230,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         XCTAssertFalse(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsLastQuestionAndShouldValidateAllAnswersOnQuestionChangeIsFalseAndAllAnswersAreValid_enablesMainButton() async throws {
@@ -222,6 +251,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         XCTAssertTrue(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsLastQuestionAndIsShouldValidateAllAnswersOnQuestionChangeIsFalseAndNotAllAnswersAreValid_disablesMainButton() async throws {
@@ -242,6 +273,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         XCTAssertFalse(viewModel.mainButtonEnabled)
+        
+        await fulfillment(of: [loggerLogError], timeout: 1)
     }
 
     func test_answer_whenIsSingleChoiceQuestionAndAnswerIsValid_enablesMainButtonAndCallsNext() async throws {
@@ -263,7 +296,7 @@ final class QuestionnaireViewModelTest: XCTestCase {
         XCTAssertEqual(viewModel.currentIndex, 0)
         XCTAssertFalse(viewModel.mainButtonEnabled)
         viewModel.answer(Mocks.singleChoiceCorrectAnswer, for: questions.first!)
-        await fulfillment(of: [sendQuestionsExpectation], timeout: 1)
+        await fulfillment(of: [sendQuestionsExpectation, loggerLogError], timeout: 1)
 
         XCTAssertEqual(viewModel.currentIndex, 1)
         XCTAssertTrue(viewModel.mainButtonEnabled)
@@ -288,7 +321,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         XCTAssertEqual(viewModel.currentIndex, 0)
         XCTAssertFalse(viewModel.mainButtonEnabled)
         viewModel.answer(Mocks.numericCorrectAnswer, for: questions.first!)
-        await fulfillment(of: [sendQuestionsExpectation], timeout: 1)
+        
+        await fulfillment(of: [sendQuestionsExpectation, loggerLogError], timeout: 1)
 
         XCTAssertEqual(viewModel.currentIndex, 0)
         XCTAssertTrue(viewModel.mainButtonEnabled)
@@ -303,11 +337,12 @@ final class QuestionnaireViewModelTest: XCTestCase {
             getQuestionsExpectation.fulfill()
             return self.questions
         }
+
         let viewModel = getViewModel(getQuestions: getQuestions)
 
         await viewModel.getQuestionnaire()
-
-        await fulfillment(of: [getQuestionsExpectation], timeout: 1)
+        await fulfillment(of: [getQuestionsExpectation, loggerLogError], timeout: 1)
+        
         XCTAssertNil(viewModel.initialLoadError)
         XCTAssertEqual(viewModel.questions, questions)
         XCTAssertEqual(viewModel.currentQuestion, questions.first)
@@ -321,11 +356,14 @@ final class QuestionnaireViewModelTest: XCTestCase {
             getQuestionsExpectation.fulfill()
             throw getQuestionsError
         }
+        
         let viewModel = getViewModel(getQuestions: getQuestions)
-
+        
+        expectErrorLogging()
+        
         await viewModel.getQuestionnaire()
-
-        await fulfillment(of: [getQuestionsExpectation], timeout: 1)
+        await fulfillment(of: [getQuestionsExpectation, loggerLogError], timeout: 1)
+        
         XCTAssertNotNil(viewModel.initialLoadError)
         XCTAssertEqual(viewModel.initialLoadError as? NSError, getQuestionsError)
         XCTAssertNil(viewModel.questions)
@@ -344,7 +382,7 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         viewModel.dismiss()
 
-        wait(for: [navigateExpectation], timeout: 1)
+        wait(for: [navigateExpectation, loggerLogError], timeout: 1)
     }
 
     // MARK: - shouldChangeToNextQuestion
@@ -359,6 +397,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.singleChoiceCorrectAnswer, isAnswerValid: true)
 
         XCTAssertTrue(result)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_shouldChangeToNextQuestion_whenQuestionIsSingleChoiceAndAnswerIsValidAndIsLastQuestion_shouldReturnFalse() {
@@ -372,6 +412,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
 
         XCTAssertFalse(result)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_shouldChangeToNextQuestion_whenQuestionIsSingleChoiceAndAnswerIsNotValidAndIsNotLastQuestion_shouldReturnFalse() {
@@ -383,8 +425,9 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.singleChoiceCorrectAnswer, isAnswerValid: false)
 
-
         XCTAssertFalse(result)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_shouldChangeToNextQuestion_whenQuestionIsMultiChoiceAndAnswerIsValidAndIsNotLastQuestion_shouldReturnFalse() {
@@ -396,8 +439,9 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.multiChoiceCorrectAnswer, isAnswerValid: true)
 
-
         XCTAssertFalse(result)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_shouldChangeToNextQuestion_whenQuestionIsNumericAndAnswerIsValidAndIsNotLastQuestion_shouldReturnFalse() {
@@ -409,8 +453,9 @@ final class QuestionnaireViewModelTest: XCTestCase {
 
         let result = viewModel.shouldChangeToNextQuestion(question: currentQuestion, answer: Mocks.numericCorrectAnswer, isAnswerValid: true)
 
-
         XCTAssertFalse(result)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     // MARK: - sendQuestionnaire
@@ -435,11 +480,13 @@ final class QuestionnaireViewModelTest: XCTestCase {
         viewModel.answers = answers
         // Place it in the last question
         viewModel.currentQuestion = questions.last
+        
+        expectErrorLogging()
 
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         viewModel.next()
 
-        await fulfillment(of: [sendQuestionsExpectation, nextScreenExpectation], timeout: 1)
+        await fulfillment(of: [sendQuestionsExpectation, nextScreenExpectation, loggerLogError], timeout: 1)
         XCTAssertEqual(sendQuestionsError, viewModel.sendError as? NSError)
     }
 
@@ -467,7 +514,7 @@ final class QuestionnaireViewModelTest: XCTestCase {
         XCTAssertEqual(viewModel.currentIndex, questions.count - 1)
         viewModel.next()
 
-        await fulfillment(of: [sendQuestionsExpectation, nextScreenExpectation], timeout: 1)
+        await fulfillment(of: [sendQuestionsExpectation, nextScreenExpectation, loggerLogError], timeout: 1)
         XCTAssertNil(viewModel.sendError)
     }
 
@@ -481,6 +528,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertFalse(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_numericQuestionWithMultiChoiceAnswerAndNotMandatory_returnsTrue() {
@@ -491,6 +540,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: false)
 
         XCTAssertTrue(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_numericQuestionWithCorrectNumericAnswer_returnsTrue() {
@@ -501,6 +552,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertTrue(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_numericQuestionWithInvalidNumericAnswer_returnsFalse() {
@@ -511,6 +564,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertFalse(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     // MARK: - validate - multiChoice
@@ -523,6 +578,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertFalse(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_multiChoiceQuestionWithNumericAnswerAndNotMandatory_returnsTrue() {
@@ -533,6 +590,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: false)
 
         XCTAssertTrue(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_multiChoiceQuestionWithCorrectMultiChoiceAnswer_returnsTrue() {
@@ -543,6 +602,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertTrue(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_multiChoiceQuestionWithEmptyMultiChoiceAnswer_returnsFalse() {
@@ -553,6 +614,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertFalse(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validate_multiChoiceQuestionWithNilMultiChoiceAnswer_returnsFalse() {
@@ -563,6 +626,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validate(answer: answer, for: question, mandatoryAnswer: true)
 
         XCTAssertFalse(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     // MARK: - validateAll
@@ -580,6 +645,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validateAll(until: questions.last!, mandatoryAnswer: true)
 
         XCTAssertTrue(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validateAll_whenSomeAnswersAreValidAndMandatory_returnsFalse() throws {
@@ -595,6 +662,8 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validateAll(until: questions.last!, mandatoryAnswer: true)
 
         XCTAssertFalse(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
 
     func test_validateAll_whenSomeAnswersAreValidAndNotMandatory_returnsTrue() throws {
@@ -610,6 +679,7 @@ final class QuestionnaireViewModelTest: XCTestCase {
         let isValid = viewModel.validateAll(until: questions.last!, mandatoryAnswer: false)
         
         XCTAssertTrue(isValid)
+        
+        wait(for: [loggerLogError], timeout: 1)
     }
-
 }

--- a/Tests/ReccoUITests/Questionnaire/TopicQuestionnaireViewModelTest.swift
+++ b/Tests/ReccoUITests/Questionnaire/TopicQuestionnaireViewModelTest.swift
@@ -9,13 +9,15 @@ final class TopicQuestionnaireViewModelTest: XCTestCase {
         topic: ReccoTopic,
         reloadSection: ((Bool) -> Void)? = nil,
         repo: QuestionnaireRepository? = nil,
-        nav: ReccoCoordinator? = nil
+        nav: ReccoCoordinator? = nil,
+        logger: Logger? = nil
     ) -> TopicQuestionnaireViewModel {
         return TopicQuestionnaireViewModel(
             topic: topic,
             reloadSection: reloadSection ?? { _ in },
             repo: repo ?? MockQuestionnaireRepository(),
-            nav: nav ?? MockRecoCoordinator()
+            nav: nav ?? MockRecoCoordinator(),
+            logger: logger ?? Logger { _ in }
         )
     }
 


### PR DESCRIPTION
Now we allow passing a logging function thru the initialize method
Updated viewModel and other parts of the code where we should log errors.
Updated test suite to expect or not error logging.
Added documentation and bumped up podspecs.