### PR TITLE
[SHAD-334] Emit app metrics

### DIFF
--- a/Sources/ReccoHeadless/Api/Generated/Models/AppUserMetricActionDTO.swift
+++ b/Sources/ReccoHeadless/Api/Generated/Models/AppUserMetricActionDTO.swift
@@ -14,6 +14,6 @@ internal enum AppUserMetricActionDTO: String, Codable, CaseIterable {
     case login = "login"
     case duration = "duration"
     case view = "view"
-	case hostAppOpen = "host_app_open"
-	case reccoSDKOpen = "recco_sdk_open"
+    case hostAppOpen = "host_app_open"
+    case reccoSDKOpen = "recco_sdk_open"
 }

--- a/Sources/ReccoHeadless/Api/Generated/Models/AppUserMetricActionDTO.swift
+++ b/Sources/ReccoHeadless/Api/Generated/Models/AppUserMetricActionDTO.swift
@@ -14,4 +14,6 @@ internal enum AppUserMetricActionDTO: String, Codable, CaseIterable {
     case login = "login"
     case duration = "duration"
     case view = "view"
+	case hostAppOpen = "host_app_open"
+	case reccoSDKOpen = "recco_sdk_open"
 }

--- a/Sources/ReccoHeadless/Assembly.swift
+++ b/Sources/ReccoHeadless/Assembly.swift
@@ -43,9 +43,13 @@ public final class ReccoHeadlessAssembly: ReccoAssembly {
             LiveQuestionnaireRepository()
         }
 
-        container.register(type: MeRepository.self, singleton: true) { r in
-            LiveMeRepository(keychain: r.get())
-        }
+		container.register(type: MetricRepository.self) { r in
+			LiveMetricRepository(keychain: r.get())
+		}
+
+		container.register(type: MeRepository.self, singleton: true) { r in
+			LiveMeRepository(keychain: r.get())
+		}
 
         container.register(type: Calendar.self) { _ in
             .current

--- a/Sources/ReccoHeadless/Assembly.swift
+++ b/Sources/ReccoHeadless/Assembly.swift
@@ -43,13 +43,13 @@ public final class ReccoHeadlessAssembly: ReccoAssembly {
             LiveQuestionnaireRepository()
         }
 
-		container.register(type: MetricRepository.self) { r in
-			LiveMetricRepository(keychain: r.get())
-		}
+        container.register(type: MetricRepository.self) { r in
+            LiveMetricRepository(keychain: r.get())
+        }
 
-		container.register(type: MeRepository.self, singleton: true) { r in
-			LiveMeRepository(keychain: r.get())
-		}
+        container.register(type: MeRepository.self, singleton: true) { r in
+            LiveMeRepository(keychain: r.get())
+        }
 
         container.register(type: Calendar.self) { _ in
             .current

--- a/Sources/ReccoHeadless/Entities/AppUserMetricAction.swift
+++ b/Sources/ReccoHeadless/Entities/AppUserMetricAction.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public enum AppUserMetricAction: String, Codable, CaseIterable {
+    case login = "login"
+    case duration = "duration"
+    case view = "view"
+    case hostAppOpen = "host_app_open"
+    case reccoSDKOpen = "recco_sdk_open"
+}

--- a/Sources/ReccoHeadless/Entities/AppUserMetricCategory.swift
+++ b/Sources/ReccoHeadless/Entities/AppUserMetricCategory.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum AppUserMetricCategory: String, Codable, CaseIterable {
+    case userSession = "user_session"
+    case dashboardScreen = "dashboard_screen"
+}

--- a/Sources/ReccoHeadless/Entities/AppUserMetricEvent.swift
+++ b/Sources/ReccoHeadless/Entities/AppUserMetricEvent.swift
@@ -6,7 +6,7 @@ public struct AppUserMetricEvent: Equatable, Hashable, Codable {
         self.action = action
         self.value = value
     }
-    
+
     public var category: AppUserMetricCategory
     public var action: AppUserMetricAction
     public var value: String?

--- a/Sources/ReccoHeadless/Entities/AppUserMetricEvent.swift
+++ b/Sources/ReccoHeadless/Entities/AppUserMetricEvent.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct AppUserMetricEvent: Equatable, Hashable, Codable {
+    public init(category: AppUserMetricCategory, action: AppUserMetricAction, value: String? = nil) {
+        self.category = category
+        self.action = action
+        self.value = value
+    }
+    
+    public var category: AppUserMetricCategory
+    public var action: AppUserMetricAction
+    public var value: String?
+}

--- a/Sources/ReccoHeadless/Repo/Repositories/MetricRepo.swift
+++ b/Sources/ReccoHeadless/Repo/Repositories/MetricRepo.swift
@@ -6,7 +6,7 @@ public protocol MetricRepository {
 
 final class LiveMetricRepository: MetricRepository {
     private let keychain: KeychainProxy
-    
+
     init(keychain: KeychainProxy) {
         self.keychain = keychain
     }

--- a/Sources/ReccoHeadless/Repo/Repositories/MetricRepo.swift
+++ b/Sources/ReccoHeadless/Repo/Repositories/MetricRepo.swift
@@ -12,7 +12,7 @@ final class LiveMetricRepository: MetricRepository {
     }
 
     func log(event: AppUserMetricEvent) {
-        guard keychain.read(account: KeychainKey.clientUserId.rawValue) != nil else { return }
+        guard keychain.read(account: KeychainKey.currentUser.rawValue) != nil else { return }
 
         Task {
             do {

--- a/Sources/ReccoHeadless/Repo/Repositories/MetricRepo.swift
+++ b/Sources/ReccoHeadless/Repo/Repositories/MetricRepo.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public protocol MetricRepository {
+    func log(event: AppUserMetricEvent)
+}
+
+final class LiveMetricRepository: MetricRepository {
+    private let keychain: KeychainProxy
+    
+    init(keychain: KeychainProxy) {
+        self.keychain = keychain
+    }
+
+    func log(event: AppUserMetricEvent) {
+        guard keychain.read(account: KeychainKey.clientUserId.rawValue) != nil else { return }
+
+        Task {
+            do {
+                try await MetricAPI.logEvent(appUserMetricEventDTO: .init(entity: event))
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/Sources/ReccoHeadless/Repo/mappers/AuthenticationMapper.swift
+++ b/Sources/ReccoHeadless/Repo/mappers/AuthenticationMapper.swift
@@ -1,5 +1,5 @@
 //
-//  AuthenticationMappers.swift
+//  AuthenticationMapper.swift
 //
 //
 //  Created by Adrián R on 1/6/23.

--- a/Sources/ReccoHeadless/Repo/mappers/MetricMapper.swift
+++ b/Sources/ReccoHeadless/Repo/mappers/MetricMapper.swift
@@ -1,0 +1,82 @@
+//
+//  MetricMapper.swift
+//  
+//
+//  Created by Roberto Frontado on 29/09/2023.
+//
+
+extension AppUserMetricEvent {
+    init(dto: AppUserMetricEventDTO) {
+        self.init(
+            category: AppUserMetricCategory(dto: dto.category),
+            action: AppUserMetricAction(dto: dto.action),
+            value: dto.value
+        )
+    }
+}
+
+extension AppUserMetricAction {
+    init(dto: AppUserMetricActionDTO) {
+        switch dto {
+        case .login:
+            self = .login
+        case .duration:
+            self = .duration
+        case .view:
+            self = .view
+        case .hostAppOpen:
+            self = .hostAppOpen
+        case .reccoSDKOpen:
+            self = .reccoSDKOpen
+        }
+    }
+}
+
+extension AppUserMetricCategory {
+    init(dto: AppUserMetricCategoryDTO) {
+        switch dto {
+        case .userSession:
+            self = .userSession
+        case .dashboardScreen:
+            self = .dashboardScreen
+        }
+    }
+}
+
+extension AppUserMetricEventDTO {
+    init(entity: AppUserMetricEvent) {
+        self.init(
+            category: AppUserMetricCategoryDTO(entity: entity.category),
+            action: AppUserMetricActionDTO(entity: entity.action),
+            value: entity.value
+        )
+    }
+}
+
+extension AppUserMetricActionDTO {
+    init(entity: AppUserMetricAction) {
+        switch entity {
+        case .login:
+            self = .login
+        case .duration:
+            self = .duration
+        case .view:
+            self = .view
+        case .hostAppOpen:
+            self = .hostAppOpen
+        case .reccoSDKOpen:
+            self = .reccoSDKOpen
+        }
+    }
+}
+
+extension AppUserMetricCategoryDTO {
+    init(entity: AppUserMetricCategory) {
+        switch entity {
+        case .userSession:
+            self = .userSession
+        case .dashboardScreen:
+            self = .dashboardScreen
+        }
+    }
+}

--- a/Sources/ReccoUI/Assembly.swift
+++ b/Sources/ReccoUI/Assembly.swift
@@ -55,10 +55,11 @@ final class ReccoUIAssembly: ReccoAssembly {
 
         container.register(type: SplashViewModel.self) { r in
             SplashViewModel(
-                repo: r.get()
+                meRepository: r.get(),
+                metricRepository: r.get()
             )
         }
-
+        
         container.register(type: TopicQuestionnaireViewModel.self) { (r: ReccoResolver, tuple: (ReccoTopic, (Bool) -> Void)) in
             TopicQuestionnaireViewModel(
                 topic: tuple.0,

--- a/Sources/ReccoUI/Assembly.swift
+++ b/Sources/ReccoUI/Assembly.swift
@@ -59,7 +59,7 @@ final class ReccoUIAssembly: ReccoAssembly {
                 metricRepository: r.get()
             )
         }
-        
+
         container.register(type: TopicQuestionnaireViewModel.self) { (r: ReccoResolver, tuple: (ReccoTopic, (Bool) -> Void)) in
             TopicQuestionnaireViewModel(
                 topic: tuple.0,

--- a/Sources/ReccoUI/Onboarding/Splash/SplashView.swift
+++ b/Sources/ReccoUI/Onboarding/Splash/SplashView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct SplashView: View {
     @StateObject var viewModel: SplashViewModel
 
+    @Environment(\.scenePhase) private var scenePhase
+
     init(viewModel: SplashViewModel) {
         self._viewModel = .init(wrappedValue: viewModel)
     }
@@ -35,6 +37,7 @@ struct SplashView: View {
     var body: some View {
         content
             .transition(.opacity)
+            .ignoresSafeArea()
             .onReceive(viewModel.$user) { newUser in
                 if _user == nil {
                     _user = newUser
@@ -44,6 +47,15 @@ struct SplashView: View {
                     }
                 }
             }
-            .ignoresSafeArea()
+            // First time the view is shown
+            .onAppear(perform: {
+                viewModel.onReccoSDKOpened()
+            })
+            // Every time the app comes from the background
+            .onChange(of: scenePhase) { phase in
+                if phase == .active {
+                    viewModel.onReccoSDKOpened()
+                }
+            }
     }
 }

--- a/Sources/ReccoUI/Onboarding/Splash/SplashView.swift
+++ b/Sources/ReccoUI/Onboarding/Splash/SplashView.swift
@@ -49,12 +49,12 @@ struct SplashView: View {
             }
             // First time the view is shown
             .onAppear(perform: {
-                viewModel.onReccoSDKOpened()
+                viewModel.onReccoSDKOpen()
             })
             // Every time the app comes from the background
             .onChange(of: scenePhase) { phase in
                 if phase == .active {
-                    viewModel.onReccoSDKOpened()
+                    viewModel.onReccoSDKOpen()
                 }
             }
     }

--- a/Sources/ReccoUI/Onboarding/Splash/SplashViewModel.swift
+++ b/Sources/ReccoUI/Onboarding/Splash/SplashViewModel.swift
@@ -4,19 +4,29 @@ import ReccoHeadless
 
 final class SplashViewModel: ObservableObject {
     var cancellable: AnyCancellable?
-    private let repo: MeRepository
+    private let meRepository: MeRepository
+    private let metricRepository: MetricRepository
 
     @Published var user: AppUser?
 
     init(
-        repo: MeRepository
+        meRepository: MeRepository,
+        metricRepository: MetricRepository
     ) {
-        self.repo = repo
+        self.meRepository = meRepository
+        self.metricRepository = metricRepository
+
         bind()
     }
 
+    func onReccoSDKOpened() {
+        metricRepository.log(event: AppUserMetricEvent(category: .userSession, action: .reccoSDKOpen))
+    }
+
+    // MARK: Private
+
     private func bind() {
-        repo
+        meRepository
             .currentUser
             .receive(on: DispatchQueue.main)
             .assign(to: &$user)

--- a/Sources/ReccoUI/Onboarding/Splash/SplashViewModel.swift
+++ b/Sources/ReccoUI/Onboarding/Splash/SplashViewModel.swift
@@ -19,7 +19,7 @@ final class SplashViewModel: ObservableObject {
         bind()
     }
 
-    func onReccoSDKOpened() {
+    func onReccoSDKOpen() {
         metricRepository.log(event: AppUserMetricEvent(category: .userSession, action: .reccoSDKOpen))
     }
 

--- a/Tests/ReccoUITests/Mocks/MockAssembly.swift
+++ b/Tests/ReccoUITests/Mocks/MockAssembly.swift
@@ -4,6 +4,7 @@
 final class MockAssembly {
     static var mockAuthRepository = MockAuthRepository()
     static var mockMeRepository = MockMeRepository()
+    static var mockMetricRepository = MockMetricRepository()
 
     private static let container = ReccoSharedContainer.shared
 
@@ -11,10 +12,12 @@ final class MockAssembly {
         // Reset dependencies
         mockAuthRepository = MockAuthRepository()
         mockMeRepository = MockMeRepository()
+        mockMetricRepository = MockMetricRepository()
 
         // Register dependencies
         container.register(type: AuthRepository.self, service: { _ in mockAuthRepository })
         container.register(type: MeRepository.self, service: { _ in mockMeRepository })
+        container.register(type: MetricRepository.self, service: { _ in mockMetricRepository })
         container.register(type: Logger.self, service: { _ in Logger { _ in didLog() } })
     }
 

--- a/Tests/ReccoUITests/Mocks/MockMetricRepository.swift
+++ b/Tests/ReccoUITests/Mocks/MockMetricRepository.swift
@@ -1,0 +1,19 @@
+@testable import ReccoHeadless
+import XCTest
+
+final class MockMetricRepository: MetricRepository {
+    enum ExpectationType {
+        case logEvent
+    }
+    
+    var expectations: [ExpectationType: XCTestExpectation] = [:]
+    var expectedEvent: AppUserMetricEvent?
+    
+    func log(event: AppUserMetricEvent) {
+        expectations[.logEvent]?.fulfill()
+        
+        if let expectedEvent = expectedEvent {
+            XCTAssertEqual(event, expectedEvent)
+        }
+    }
+}

--- a/Tests/ReccoUITests/Mocks/MockMetricRepository.swift
+++ b/Tests/ReccoUITests/Mocks/MockMetricRepository.swift
@@ -5,13 +5,13 @@ final class MockMetricRepository: MetricRepository {
     enum ExpectationType {
         case logEvent
     }
-    
+
     var expectations: [ExpectationType: XCTestExpectation] = [:]
     var expectedEvent: AppUserMetricEvent?
-    
+
     func log(event: AppUserMetricEvent) {
         expectations[.logEvent]?.fulfill()
-        
+
         if let expectedEvent = expectedEvent {
             XCTAssertEqual(event, expectedEvent)
         }

--- a/Tests/ReccoUITests/Onboarding/SplashViewModelTest.swift
+++ b/Tests/ReccoUITests/Onboarding/SplashViewModelTest.swift
@@ -37,7 +37,7 @@ final class SplashViewModelTest: XCTestCase {
         mockMetricRepository.expectations[.logEvent] = logEventExpectation
         mockMetricRepository.expectedEvent = event
 
-        viewModel.onReccoSDKOpened()
+        viewModel.onReccoSDKOpen()
         wait(for: [logEventExpectation], timeout: 1)
     }
 }

--- a/Tests/ReccoUITests/Onboarding/SplashViewModelTest.swift
+++ b/Tests/ReccoUITests/Onboarding/SplashViewModelTest.swift
@@ -8,13 +8,14 @@ final class SplashViewModelTest: XCTestCase {
 
     func test_init_whenCurrentUserChanges_itUpdatesUser() {
         let mockMeRepository = MockMeRepository()
-        let viewModel = SplashViewModel(repo: mockMeRepository)
+        let mockMetricRepository = MockMetricRepository()
+        let viewModel = SplashViewModel(meRepository: mockMeRepository, metricRepository: mockMetricRepository)
         let user = AppUser(id: "id", isOnboardingQuestionnaireCompleted: true)
 
         XCTAssertNil(viewModel.user)
         mockMeRepository._currentUser.value = user
 
-		// swiftlint:disable:next todo
+        // swiftlint:disable:next todo
         // TODO: Improve me
         // Workaround to test ".receive(on: DispatchQueue.main)". We  need a way to pass that Scheduler from outside
         let expectation = self.expectation(description: "Test")
@@ -22,5 +23,21 @@ final class SplashViewModelTest: XCTestCase {
         wait(for: [expectation], timeout: 1)
 
         XCTAssertEqual(user, viewModel.user)
+    }
+
+    // MARK: - onReccoSDKOpen
+
+    func test_onReccoSDKOpen_logsReccoSDKOpenEvent() {
+        let mockMeRepository = MockMeRepository()
+        let mockMetricRepository = MockMetricRepository()
+        let viewModel = SplashViewModel(meRepository: mockMeRepository, metricRepository: mockMetricRepository)
+
+        let event = AppUserMetricEvent(category: .userSession, action: .reccoSDKOpen)
+        let logEventExpectation = expectation(description: "log was not called")
+        mockMetricRepository.expectations[.logEvent] = logEventExpectation
+        mockMetricRepository.expectedEvent = event
+
+        viewModel.onReccoSDKOpened()
+        wait(for: [logEventExpectation], timeout: 1)
     }
 }

--- a/Tests/ReccoUITests/PublicAPITest.swift
+++ b/Tests/ReccoUITests/PublicAPITest.swift
@@ -75,4 +75,49 @@ final class PublicAPITest: XCTestCase {
 
         await fulfillment(of: [logoutExpectation])
     }
+
+    // MARK: - addLifecycleObserversForMetrics
+
+    func test_addLifecycleObserversForMetrics_whenCalled_logsHostAppOpenEvent() async {
+        MockAssembly.assemble()
+        let mockMetricRepository = MockAssembly.mockMetricRepository
+
+        let event = AppUserMetricEvent(category: .userSession, action: .hostAppOpen)
+        let logEventExpectation = expectation(description: "log was not called")
+        mockMetricRepository.expectations[.logEvent] = logEventExpectation
+        mockMetricRepository.expectedEvent = event
+
+        ReccoUI.addLifecycleObserversForMetrics()
+
+        await fulfillment(of: [logEventExpectation], timeout: 1)
+    }
+
+    func test_addLifecycleObserversForMetrics_whenWillEnterForegroundNotificationIsEmitted_logsHostAppOpenEvent() async {
+        MockAssembly.assemble()
+        let mockMetricRepository = MockAssembly.mockMetricRepository
+        ReccoUI.addLifecycleObserversForMetrics()
+
+        let event = AppUserMetricEvent(category: .userSession, action: .hostAppOpen)
+        let logEventExpectation = expectation(description: "log was not called")
+        mockMetricRepository.expectations[.logEvent] = logEventExpectation
+        mockMetricRepository.expectedEvent = event
+
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        await fulfillment(of: [logEventExpectation], timeout: 1)
+    }
+
+    func test_addLifecycleObserversForMetrics_whendidEnterBackgroundNotificationIsEmitted_doesNotlogsHostAppOpenEvent() async {
+        MockAssembly.assemble()
+        let mockMetricRepository = MockAssembly.mockMetricRepository
+        ReccoUI.addLifecycleObserversForMetrics()
+
+        let logEventExpectation = expectation(description: "log was called")
+        logEventExpectation.isInverted = true
+        mockMetricRepository.expectations[.logEvent] = logEventExpectation
+
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        await fulfillment(of: [logEventExpectation], timeout: 1)
+    }
 }


### PR DESCRIPTION
### Jira
https://vilua.atlassian.net/browse/SHAD-334

### Context
Emitting 2 events (Only when the user is authenticated):
- HOST_APP_OPEN
- RECCO_SDK_OPEN

I chose to use UINotificationCenter to be able to hook into the host application lifecycle without requiring the client to do any extra steps. The other options I considered were to expose some lifecycle methods and good ol' swizzling 😅  none were optimal for an SDK.

### Media
https://github.com/SignificoHealth/recco-ios-sdk/assets/11177510/684d1c0e-6e78-4dfb-8f03-d8d14fd46ebb

