### PR TITLE
[SHAD-337][SHAD-374] Fix metrics in iOS 16 and duplicate event 

### DIFF
--- a/Sources/ReccoUI/Onboarding/Splash/SplashView.swift
+++ b/Sources/ReccoUI/Onboarding/Splash/SplashView.swift
@@ -4,8 +4,6 @@ import SwiftUI
 struct SplashView: View {
     @StateObject var viewModel: SplashViewModel
 
-    @Environment(\.scenePhase) private var scenePhase
-
     init(viewModel: SplashViewModel) {
         self._viewModel = .init(wrappedValue: viewModel)
     }
@@ -52,10 +50,8 @@ struct SplashView: View {
                 viewModel.onReccoSDKOpen()
             })
             // Every time the app comes from the background
-            .onChange(of: scenePhase) { phase in
-                if phase == .active {
-                    viewModel.onReccoSDKOpen()
-                }
+            .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                viewModel.onReccoSDKOpen()
             }
     }
 }

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -102,7 +102,7 @@ internal func addLifecycleObserversForMetrics() {
 
     // Emit when the host app enters foreground, it will emit once when the sdk is initialized during the start up of the app
     NotificationCenter.default
-        .publisher(for: UIApplication.willEnterForegroundNotification)
+        .publisher(for: UIApplication.didBecomeActiveNotification)
         .sink { _ in
             metricRepository.log(event: AppUserMetricEvent(category: .userSession, action: .hostAppOpen))
         }

--- a/Sources/ReccoUI/PublicAPI.swift
+++ b/Sources/ReccoUI/PublicAPI.swift
@@ -100,10 +100,7 @@ internal func addLifecycleObserversForMetrics() {
 
     let metricRepository: MetricRepository = get()
 
-    // Emit when the sdk is initialized
-    metricRepository.log(event: AppUserMetricEvent(category: .userSession, action: .hostAppOpen))
-
-    // Emit when the host app enters foreground
+    // Emit when the host app enters foreground, it will emit once when the sdk is initialized during the start up of the app
     NotificationCenter.default
         .publisher(for: UIApplication.willEnterForegroundNotification)
         .sink { _ in

--- a/Tests/ReccoUITests/PublicAPITest.swift
+++ b/Tests/ReccoUITests/PublicAPITest.swift
@@ -78,20 +78,6 @@ final class PublicAPITest: XCTestCase {
 
     // MARK: - addLifecycleObserversForMetrics
 
-    func test_addLifecycleObserversForMetrics_whenCalled_logsHostAppOpenEvent() async {
-        MockAssembly.assemble()
-        let mockMetricRepository = MockAssembly.mockMetricRepository
-
-        let event = AppUserMetricEvent(category: .userSession, action: .hostAppOpen)
-        let logEventExpectation = expectation(description: "log was not called")
-        mockMetricRepository.expectations[.logEvent] = logEventExpectation
-        mockMetricRepository.expectedEvent = event
-
-        ReccoUI.addLifecycleObserversForMetrics()
-
-        await fulfillment(of: [logEventExpectation], timeout: 1)
-    }
-
     func test_addLifecycleObserversForMetrics_whenWillEnterForegroundNotificationIsEmitted_logsHostAppOpenEvent() async {
         MockAssembly.assemble()
         let mockMetricRepository = MockAssembly.mockMetricRepository

--- a/Tests/ReccoUITests/PublicAPITest.swift
+++ b/Tests/ReccoUITests/PublicAPITest.swift
@@ -78,7 +78,7 @@ final class PublicAPITest: XCTestCase {
 
     // MARK: - addLifecycleObserversForMetrics
 
-    func test_addLifecycleObserversForMetrics_whenWillEnterForegroundNotificationIsEmitted_logsHostAppOpenEvent() async {
+    func test_addLifecycleObserversForMetrics_whenDidBecomeActiveNotificationIsEmitted_logsHostAppOpenEvent() async {
         MockAssembly.assemble()
         let mockMetricRepository = MockAssembly.mockMetricRepository
         ReccoUI.addLifecycleObserversForMetrics()
@@ -88,7 +88,7 @@ final class PublicAPITest: XCTestCase {
         mockMetricRepository.expectations[.logEvent] = logEventExpectation
         mockMetricRepository.expectedEvent = event
 
-        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         await fulfillment(of: [logEventExpectation], timeout: 1)
     }


### PR DESCRIPTION
**Changes**
- Refactored SplashView to rely on notifications rather than scenePhase changes
- Change from `willEnterForegroundNotification` to `didBecomeActiveNotification`
- When the SDK gets initialized it emits twice the event HOST_APP_OPEN, because the SDK receives the notification `UIApplication.didBecomeActiveNotification` right after the SDK initializes (because the app is just opened)

**Media**
https://github.com/SignificoHealth/recco-ios-sdk/assets/11177510/f1f12b7c-6bc2-4cb5-804d-c64a8f03f75c
