### PR TITLE
Fixed redundancy close button on errorview

### DIFF
--- a/Sources/ReccoUI/Dashboard/DashboardView/DashboardView.swift
+++ b/Sources/ReccoUI/Dashboard/DashboardView/DashboardView.swift
@@ -43,8 +43,7 @@ struct DashboardView: View {
         }
         .reccoErrorView(
             error: $viewModel.initialLoadError,
-            onRetry: { await viewModel.getFeedItems() },
-            onClose: viewModel.dismiss
+            onRetry: { await viewModel.getFeedItems() }
         )
         .background(
             Color.reccoBackground.ignoresSafeArea()


### PR DESCRIPTION
This happened because before we did not have a navigationbar always visible on the dashboard, so the button was necessary there, but not anymore.

This is how it looks now: 

<img src="https://github.com/SignificoHealth/recco-ios-sdk/assets/2614596/839593a5-2a06-42f2-ac21-8ce46e5dade8" width="300">
